### PR TITLE
goreleaser.yml: Set CXX for 'zig c++'

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,8 +26,8 @@ builds:
         {{- end }}
     - >-
         {{- if eq .Os "darwin" }}
-          {{- if eq .Arch "amd64"}}CC=zig c++ -target x86_64-macos-none -F{{ .Env.SDK_PATH }}/System/Library/Frameworks{{- end }}
-          {{- if eq .Arch "arm64"}}CC=zig c++ -target aarch64-macos-none -F{{ .Env.SDK_PATH }}/System/Library/Frameworks{{- end }}
+          {{- if eq .Arch "amd64"}}CXX=zig c++ -target x86_64-macos-none -F{{ .Env.SDK_PATH }}/System/Library/Frameworks{{- end }}
+          {{- if eq .Arch "arm64"}}CXX=zig c++ -target aarch64-macos-none -F{{ .Env.SDK_PATH }}/System/Library/Frameworks{{- end }}
         {{- end }}
   
   - id: goreleaser-zig-cross-compilation-linux
@@ -49,8 +49,8 @@ builds:
         {{- end }}
     - >-
         {{- if eq .Os "linux" }}
-          {{- if eq .Arch "amd64" }}CC=zig c++ -target x86_64-linux-musl{{- end }}
-          {{- if eq .Arch "arm64"}}CC=zig c++ -target aarch64-linux-musl{{- end }}
+          {{- if eq .Arch "amd64" }}CXX=zig c++ -target x86_64-linux-musl{{- end }}
+          {{- if eq .Arch "arm64"}}CXX=zig c++ -target aarch64-linux-musl{{- end }}
         {{- end }}
 
   - id: goreleaser-zig-cross-compilation-windows
@@ -72,8 +72,8 @@ builds:
         {{- end }}
     - >-
         {{- if eq .Os "windows" }}
-          {{- if eq .Arch "amd64" }}CC=zig c++ -target x86_64-windows-gnu{{- end }}
-          {{- if eq .Arch "arm64"}}CC=zig c++ -target aarch64-windows-gnu{{- end }}
+          {{- if eq .Arch "amd64" }}CXX=zig c++ -target x86_64-windows-gnu{{- end }}
+          {{- if eq .Arch "arm64"}}CXX=zig c++ -target aarch64-windows-gnu{{- end }}
         {{- end }}
 
 archives:


### PR DESCRIPTION
Updates the example goreleaser.yaml
to set `CXX` for `zig c++`, not `CC`.

I think this is what was intended per the README.